### PR TITLE
Fix compilation for visionOS

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,7 @@ If you still have a question, enhancement, or a way to improve Pow, this project
 - iOS 15.0+
 - macOS 12.0
 - Mac Catalyst 15.0+
+- visionOS beta 6 (requires Xcode 15.1 beta 3)
 
 ## Change Effects
 
@@ -136,7 +137,7 @@ The shape will be colored by the current tint style.
 ```
 
  An effect that adds one or more shapes that slowly grow and fade-out behind the view.
- 
+
  - Parameters:
    - `shape`: The shape to use for the effect.
    - `style`: The style to use for the effect.

--- a/Sources/Pow/Effects/SmokeEffect.swift
+++ b/Sources/Pow/Effects/SmokeEffect.swift
@@ -54,7 +54,7 @@ private struct SmokeEffect: ViewModifier, Continuous {
         GeometryReader { proxy in
             ZStack {
                 ForEach(Array(particles.enumerated()), id: \.element) { (offset, particle) in
-                    #if os(iOS)
+                    #if os(iOS) || os(visionOS)
                     let image = UIImage(named: particle, in: .module, with: nil)!.cgImage!
                     #elseif os(macOS)
                     let image = Bundle.module.image(forResource: particle)!.cgImage(forProposedRect: nil, context: nil, hints: nil)!
@@ -67,7 +67,7 @@ private struct SmokeEffect: ViewModifier, Continuous {
     }
 }
 
-#if os(iOS)
+#if os(iOS) || os(visionOS)
 private class EmitterView: UIView {
     override class var layerClass : AnyClass {
        return CAEmitterLayer.self

--- a/Sources/Pow/Infrastructure/ViewRepresentable.swift
+++ b/Sources/Pow/Infrastructure/ViewRepresentable.swift
@@ -1,6 +1,6 @@
 import SwiftUI
 
-#if os(iOS) || os(tvOS)
+#if os(iOS) || os(tvOS) || os(visionOS)
 protocol ViewRepresentable: UIViewRepresentable {
     associatedtype ViewType = UIViewType
     func makeView(context: Context) -> ViewType


### PR DESCRIPTION
This PR fixes #45 by updating the compiler control statements to add the missing `os(visionOS)` platform condition check.

The project now builds for visionOS, but with warnings as it is build against the latest version of SwiftUI which deprecates [`View.onChange(of:perform:)`](https://developer.apple.com/documentation/SwiftUI/View/onChange(of:perform:)) in favor of [`View.onChange(of:initial:_:)`](https://developer.apple.com/documentation/swiftui/view/onchange(of:initial:_:)-8wgw9). 

I can tackle the warnings in another PR, I'd still love to get this in if possible because compilation on visionOS is at the moment.