### PR TITLE
Fix ControlSize.extraLarge not available for Xcode lower than 15

### DIFF
--- a/Sources/Pow/Infrastructure/AngleControl.swift
+++ b/Sources/Pow/Infrastructure/AngleControl.swift
@@ -35,14 +35,17 @@ struct AngleControl<Label: View>: View {
     }
 
     private var size: CGFloat {
-        switch controlSize {
-        case .mini: return 32
-        case .small: return 38
-        case .regular: return 44
-        case .large: return 54
-        case .extraLarge: return 54
-        @unknown default: return 44
-        }
+      switch controlSize {
+      case .mini: return 32
+      case .small: return 38
+      case .regular: return 44
+      case .large: return 54
+#if compiler(>=5.9)
+      // ControlSize.extraLarge is only available from Xcode 15 which comes with Swift 5.9
+      case .extraLarge: return 54
+#endif
+      @unknown default: return 44
+      }
     }
 
     var body: some View {


### PR DESCRIPTION
This PR adds a compiler option to ignore ControlSize.extraLarge in case it is now available.
Since Xcode doesn't provide a way to check for available SDKs, I can only do this with the Swift version that comes with Xcode 15.

Fixes: #46 