### PR TITLE
Avoid reapplying all RepeatingChangeEffectModifier changes in second onAppear

### DIFF
--- a/Sources/Pow/Infrastructure/WhileEffect.swift
+++ b/Sources/Pow/Infrastructure/WhileEffect.swift
@@ -136,6 +136,9 @@ private struct RepeatingChangeEffectModifier: ViewModifier {
                     timer.resume(interval: interval, delay: effect.delay)
                 }
             }
+            .onDisappear {
+                timer.pause()
+            }
             .onChange(of: isEnabled) { isEnabled in
                 if isEnabled {
                     timer.resume(interval: interval, delay: effect.delay)


### PR DESCRIPTION
When using an effect as `RepeatingChangeEffectModifier` inside of a lazy stack it is possible that `onAppear` is called multiple times when the view comes back being visible. That would cause the shine effect to repeat `RepeatingChangeEffectModifier.timer.count` times when becoming visible again. This PR tries to fix this by pausing/resetting the timer count when the view disappears. I hope this is the correct way to solve this 🙂

<table>
<tr>
 <td> 

```swift
ScrollView {
    LazyVStack {
        ForEach(0...50, id: \.self) { _ in
            Button { } label: {
                Label("Shine", systemImage: "sun.horizon.fill")
            }
            .buttonStyle(.borderedProminent)
            .controlSize(.large)
            .conditionalEffect(.repeat(.shine, every: .seconds(1)), condition: true)
        }
    }
}
```
 <td>

https://github.com/EmergeTools/Pow/assets/9310224/67531f90-04d9-476d-a283-ada50ec78ebb
</table>
