### PR TITLE
Adding custom phase length options for WiggleRate and ShakeRate

### DIFF
--- a/Sources/Pow/Effects/ShakeEffect.swift
+++ b/Sources/Pow/Effects/ShakeEffect.swift
@@ -12,13 +12,13 @@ public extension AnyChangeEffect {
     enum ShakeRate {
         case `default`
         case fast
-        case customPhaseLength(CGFloat)
+        case phaseLength(CGFloat)
 
         fileprivate var phaseLength: CGFloat {
             switch self {
             case .default: return 0.8
             case .fast: return 0.3
-            case .customPhaseLength(let phaseLength): return phaseLength
+            case .phaseLength(let phaseLength): return phaseLength
             }
         }
     }

--- a/Sources/Pow/Effects/ShakeEffect.swift
+++ b/Sources/Pow/Effects/ShakeEffect.swift
@@ -12,11 +12,13 @@ public extension AnyChangeEffect {
     enum ShakeRate {
         case `default`
         case fast
+        case customPhaseLength(CGFloat)
 
         fileprivate var phaseLength: CGFloat {
             switch self {
             case .default: return 0.8
             case .fast: return 0.3
+            case .customPhaseLength(let phaseLength): return phaseLength
             }
         }
     }

--- a/Sources/Pow/Effects/WiggleEffect.swift
+++ b/Sources/Pow/Effects/WiggleEffect.swift
@@ -10,13 +10,13 @@ public extension AnyChangeEffect {
     enum WiggleRate {
         case `default`
         case fast
-        case customPhaseLength(CGFloat)
+        case phaseLength(CGFloat)
 
         fileprivate var phaseLength: CGFloat {
             switch self {
             case .default: return 0.8
             case .fast: return 0.3
-            case .customPhaseLength(let phaseLength): return phaseLength
+            case .phaseLength(let phaseLength): return phaseLength
             }
         }
     }

--- a/Sources/Pow/Effects/WiggleEffect.swift
+++ b/Sources/Pow/Effects/WiggleEffect.swift
@@ -10,11 +10,13 @@ public extension AnyChangeEffect {
     enum WiggleRate {
         case `default`
         case fast
+        case customPhaseLength(CGFloat)
 
         fileprivate var phaseLength: CGFloat {
             switch self {
             case .default: return 0.8
             case .fast: return 0.3
+            case .customPhaseLength(let phaseLength): return phaseLength
             }
         }
     }


### PR DESCRIPTION
This addresses #30, and adds the same functionality for ShakeRate.