### PR TITLE
Start/stop engine when entering background/foreground

### DIFF
--- a/Sources/Pow/Infrastructure/Haptics.swift
+++ b/Sources/Pow/Infrastructure/Haptics.swift
@@ -5,7 +5,14 @@ import CoreHaptics
 
 internal struct Haptics {
     private static var engine: CHHapticEngine? = {
-        return try? CHHapticEngine()
+        let engine = try? CHHapticEngine()
+        NotificationCenter.default.addObserver(forName: UIApplication.didEnterBackgroundNotification, object: nil, queue: nil) { _ in
+            engine?.stop()
+        }
+        NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification, object: nil, queue: nil) { _ in
+            try? engine?.start()
+        }
+        return engine
     }()
 
     private static var supportsHaptics = CHHapticEngine.capabilitiesForHardware().supportsHaptics

--- a/Sources/Pow/Infrastructure/Haptics.swift
+++ b/Sources/Pow/Infrastructure/Haptics.swift
@@ -6,14 +6,20 @@ import CoreHaptics
 internal struct Haptics {
     private static var engine: CHHapticEngine? = {
         let engine = try? CHHapticEngine()
+        addHapticEngineObservers()
+        return engine
+    }()
+  
+    private static func addHapticEngineObservers() {
+        // Without stopping the CHHapticEngine when entering background mode, haptics are not played when the app enters the foreground.
+        // See https://github.com/EmergeTools/Pow/issues/69
         NotificationCenter.default.addObserver(forName: UIApplication.didEnterBackgroundNotification, object: nil, queue: nil) { _ in
             engine?.stop()
         }
         NotificationCenter.default.addObserver(forName: UIApplication.willEnterForegroundNotification, object: nil, queue: nil) { _ in
             try? engine?.start()
         }
-        return engine
-    }()
+    }
 
     private static var supportsHaptics = CHHapticEngine.capabilitiesForHardware().supportsHaptics
 


### PR DESCRIPTION
Hi there,

This PR resolves issue #69.

My original assumption was that `usesCustomHaptics` was created to cover all the scene phase changes. Unfortunately, it does not cover them all. Hard to tell why, as `_AppearanceActionModifier` is a hidden API 🤭
```
func usesCustomHaptics() -> some View {
    modifier(
        _AppearanceActionModifier {
            Haptics.acquire()
        } disappear: {
            Haptics.release()
        }
    )
}
```

Steps to reproduce: Check the haptics associated with the `Spray` effect. Then minimize the app and open it again. Before the change, the haptics wouldn't work. 

With the change, the Spray effect provides a full experience again 🥰

I'm aware of the `@Environment(\.scenePhase)`. However, `Haptics` are implemented as a set of static methods, so connecting `scenePhases` with it does not make much sense to me, but I'm happy to hear your opinion. 
`Haptics` are shipped to iOS targets only, so using `NotificationCenter` is safe.