### PR TITLE
Fix SwiftPM build

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,6 +30,7 @@ let package = Package(
         .target(
             name: "Pow",
             dependencies: enablePreviews ? [.product(name: "SnapshotPreferences", package: "SnapshotPreviews-iOS", condition: .when(platforms: [.iOS]))] : [],
+            resources: [.process("Assets.xcassets")],
             swiftSettings: enablePreviews ? [.define("EMG_PREVIEWS")] : nil),
         .testTarget(
             name: "PowTests",


### PR DESCRIPTION
With Xcode 16 / Swift 6.0, it's possible to build iOS libraries using SwiftPM / `swift-build`:

```bash
$ swift build --triple arm64-apple-ios --sdk "$(xcrun -sdk iphoneos -show-sdk-path)"
```

However, there's a small discrepancy (arguably an underspecification) between the XCBuild and SwiftPM build systems: XCBuild appears to process `xcassets` files automatically whereas SwiftPM requires explicitly declaring them as resources. This causes the build to fail.

```bash
$ swift build --triple arm64-apple-ios --sdk "$(xcrun -sdk iphoneos -show-sdk-path)"
warning: 'pow': found 1 file(s) which are unhandled; explicitly declare them as resources or exclude from the target
    [...]/Pow/Sources/Pow/Assets.xcassets
Building for debugging...
[...]/Pow/Sources/Pow/Effects/SmokeEffect.swift:61:63: error: type 'Bundle?' has no member 'module'
```

This PR makes a one line fix that allows Pow to build with XCBuild as well as SwiftPM.

```patch
--- a/Package.swift
+++ b/Package.swift
@@ -30,6 +30,7 @@ let package = Package(
         .target(
             name: "Pow",
             dependencies: enablePreviews ? [.product(name: "SnapshotPreferences", package: "SnapshotPreviews-iOS", condition: .when(platforms: [.iOS]))] : [],
+            resources: [.process("Assets.xcassets")],
             swiftSettings: enablePreviews ? [.define("EMG_PREVIEWS")] : nil),
         .testTarget(
             name: "PowTests",
```